### PR TITLE
Autodoc fixes

### DIFF
--- a/.github/workflows/main-deploy-docs.yml
+++ b/.github/workflows/main-deploy-docs.yml
@@ -3,8 +3,15 @@
 
 name: deploy-docs
 
-# Controls when the action will run. 
+# Controls when the action will run.
 on:
+  # All non-beta tag pushes.
+  push:
+    tags:
+      - 'v*'
+    except:
+      - 'v*b*'
+
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
@@ -22,4 +29,4 @@ jobs:
       - name: Docs
         env:
           DOCS_TOKEN: ${{ secrets.DOCS_TOKEN }}
-        run: curl -X POST -d "branches=master" -d "token=$DOCS_TOKEN" https://readthedocs.org/api/v2/webhook/submitr/246175/
+        run: curl -X POST -d "ref=master" -d "token=$DOCS_TOKEN" https://readthedocs.org/api/v2/webhook/submitr/246175/

--- a/.github/workflows/main-deploy-docs.yml
+++ b/.github/workflows/main-deploy-docs.yml
@@ -12,9 +12,6 @@ on:
     except:
       - 'v*b*'
 
-  # Allows you to run this workflow manually from the Actions tab
-  workflow_dispatch:
-
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   # This workflow contains a single job called "build"

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,10 +6,15 @@ submitr
 Change Log
 ----------
 
-0.4.0
+0.3.1
 =====
 
 * Auto-submit to readthedocs on any non-beta version tag push (v* except v*b*).
+* Fix a bug in readthedocs submission where we were using branches=master and getting an error saying
+  ``{"detail":"Parameter \"ref\" is required"}``. ChatGPT thinks this is because we wanted a curl
+  parameter of ``-d "ref=master"`` rather than ``-d "branches=master"`` like we had.
+* Remove spurious "Module Contents" headings in three places.
+  We do not put code in ``__init__.py`` so these sections would always be empty (and confusing).
 
 
 0.3.0

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,12 @@ submitr
 Change Log
 ----------
 
+0.4.0
+=====
+
+* Auto-submit to readthedocs on any non-beta version tag push (v* except v*b*).
+
+
 0.3.0
 =====
 

--- a/docs/source/submitr.rst
+++ b/docs/source/submitr.rst
@@ -44,11 +44,3 @@ submitr.utils module
    :members:
    :undoc-members:
    :show-inheritance:
-
-Module contents
----------------
-
-.. automodule:: submitr
-   :members:
-   :undoc-members:
-   :show-inheritance:

--- a/docs/source/submitr.scripts.rst
+++ b/docs/source/submitr.scripts.rst
@@ -35,11 +35,3 @@ submitr.scripts.upload\_item\_data module
    :members:
    :undoc-members:
    :show-inheritance:
-
-Module contents
----------------
-
-.. automodule:: submitr.scripts
-   :members:
-   :undoc-members:
-   :show-inheritance:

--- a/docs/source/submitr.tests.rst
+++ b/docs/source/submitr.tests.rst
@@ -67,11 +67,3 @@ submitr.tests.test\_utils module
    :members:
    :undoc-members:
    :show-inheritance:
-
-Module contents
----------------
-
-.. automodule:: submitr.tests
-   :members:
-   :undoc-members:
-   :show-inheritance:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "submitr"
-version = "0.3.0"
+version = "0.3.1"
 description = "Support for uploading file submissions to SMAHT."
 # TODO: Update this email address when a more specific one is available for SMaHT.
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]


### PR DESCRIPTION
* This is slightly experimental but I don't know how to test it without just putting it up and it's broken now anyway, so hopefully it's all fine. It will make it deploy on tag, but what was broken was something about a missing "ref" argument, so I've changed "branches=master" to "ref=master". Hopefully that will help.

Also, the doc comes up with useless "Module Content" headings that don't actually ever have content so I'm removing those. You'd have to put stuff in `__init__.py` for those to be non-empty, and I have no taste for that.